### PR TITLE
Adds include to energy_functions.h

### DIFF
--- a/jbw/energy_functions.h
+++ b/jbw/energy_functions.h
@@ -17,6 +17,7 @@
 #ifndef ENERGY_FUNCTIONS_H_
 #define ENERGY_FUNCTIONS_H_
 
+#include <math.h>
 #include "position.h"
 
 namespace jbw {


### PR DESCRIPTION
Adds an include to energy_functions.h. With certain compiler settings, the missing `#include` prevents the code from compiling.