### PR TITLE
Migrate setup.py to setuptools, making the package pip-installable

### DIFF
--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "numpy >= 1.15"]

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -12,16 +12,16 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from distutils.core import setup, Extension
-from distutils.command.build_ext import build_ext
-from os import environ
+from setuptools import setup, Extension, build_ext
+
 import numpy as np
+from os import environ
 
 extra_compile_args = {
-    'msvc' : ['/W3', '/GT', '/Gy', '/Oi', '/Ox', '/Ot', '/Oy', '/DNDEBUG', '/DUNICODE'],
-    'unix' : ['-std=c++11', '-Wall', '-Wpedantic', '-Ofast', '-DNDEBUG', '-fno-stack-protector', '-mtune=native', '-march=native']}
+    'msvc': ['/W3', '/GT', '/Gy', '/Oi', '/Ox', '/Ot', '/Oy', '/DNDEBUG', '/DUNICODE'],
+    'unix': ['-std=c++11', '-Wall', '-Wpedantic', '-Ofast', '-DNDEBUG', '-fno-stack-protector', '-mtune=native', '-march=native']}
 extra_link_args = {
-    'msvc' : ['ws2_32.lib']}
+    'msvc': ['ws2_32.lib']}
 
 # on Mac, if gcc is used, '-Qunused-arguments' will throw an error
 if 'CFLAGS' in environ:
@@ -40,25 +40,23 @@ class build_ext_subclass(build_ext):
         e.extra_link_args = extra_link_args[c]
     build_ext.build_extensions(self)
 
-simulator_c = Extension(
-  'jbw.simulator_c',
-  define_macros = [('MAJOR_VERSION', '1'),
-                   ('MINOR_VERSION', '0')],
-  include_dirs = ['../../jbw', '../../jbw/deps', np.get_include()],
-  # libraries = ['...'],
-  # library_dirs = ['/usr/local/lib'],
-  sources = ['src/jbw/simulator.cpp'])
 
-with open('../../README.md', 'r') as f:
-    readme = f.read()
+
+simulator_c = Extension(
+    'jbw.simulator_c',
+    define_macros=[('MAJOR_VERSION', '1'), ('MINOR_VERSION', '0')],
+    include_dirs=['../../jbw', '../../jbw/deps', np.get_include()],
+    sources=['src/jbw/simulator.cpp'])
+
 setup(
-  name = 'jbw',
-  version = '1.0',
-  license='Apache License 2.0',
-  description = 'Jelly Bean World',
-  long_description = readme,
-  ext_modules = [simulator_c],
-  packages = ['jbw'],
-  package_dir = {'': 'src'},
-  install_requires = ['enum34'],
-  cmdclass = {'build_ext' : build_ext_subclass} )
+    name='jbw',
+    version='1.0',
+    license='Apache License 2.0',
+    description='Jelly Bean World',
+    long_description=open('../../README.md').read(),
+    ext_modules=[simulator_c],
+    packages=['jbw'],
+    package_dir={'': 'src'},
+    install_requires=['enum34'],
+    cmdclass={'build_ext': build_ext_subclass})
+

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -12,9 +12,10 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from setuptools import setup, Extension, build_ext
-
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
 import numpy as np
+
 from os import environ
 
 extra_compile_args = {

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -58,5 +58,6 @@ setup(
     ext_modules=[simulator_c],
     packages=['jbw'],
     package_dir={'': 'src'},
-    install_requires=['enum34', 'numpy'],
+    setup_requires=['numpy'],
+    install_requires=['enum34'],
     cmdclass={'build_ext': build_ext_subclass})

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -58,6 +58,5 @@ setup(
     ext_modules=[simulator_c],
     packages=['jbw'],
     package_dir={'': 'src'},
-    install_requires=['enum34'],
+    install_requires=['enum34', 'numpy'],
     cmdclass={'build_ext': build_ext_subclass})
-


### PR DESCRIPTION
I made some minor changes to setup.py and added a pyproject and the simulator should be pip-installable now. You can test this yourself with the following:

```
❯ python3.10 -m venv ./venv
❯ source ./venv/bin/activate
❯ pip install 'git+ssh://git@github.com/ckchow/jelly-bean-world@cchow/install-pep-compliance#subdirectory=api/python'
```